### PR TITLE
OSS-26: Update checksum file

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Schedule
 
 on:
   # allow to manual run the action

--- a/cli.ts
+++ b/cli.ts
@@ -53,13 +53,20 @@ yargs(hideBin(process.argv))
     'update [standard]',
     'update for a standard',
     function (yargs) {
-      return yargs.option('s', {
-        alias: 'standard',
-        describe: 'the standard to check for updates',
-        type: 'string',
-        choices: ['xbau', 'xbau-kernmodul'],
-        default: 'xbau',
-      });
+      return yargs
+        .option('s', {
+          alias: 'standard',
+          describe: 'the standard to check for updates',
+          type: 'string',
+          choices: ['xbau', 'xbau-kernmodul'],
+          default: 'xbau',
+        })
+        .option('w', {
+          alias: 'write',
+          describe: 'Update the checksum file if it is outdated',
+          type: 'boolean',
+          default: true,
+        });
     },
     async (argv) => {
       const standard = argv.standard as string;
@@ -67,10 +74,10 @@ yargs(hideBin(process.argv))
         console.error('Invalid standard. Please choose either "xbau" or "xbau-kernmodul".');
       }
       if (standard === 'xbau-kernmodul') {
-        const update = await isUpdateAvailableForStandard(Standard.XBAU_KERN);
+        const update = await isUpdateAvailableForStandard(Standard.XBAU_KERN, argv.write as boolean);
         console.log('Update available for XBAU Kernmodul:', update);
       } else {
-        const update = await isUpdateAvailableForStandard(Standard.XBAU);
+        const update = await isUpdateAvailableForStandard(Standard.XBAU, argv.write as boolean);
         console.log('Update available for XBAU:', update);
       }
     }

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -30,7 +30,7 @@ async function writeToFile(file: string, content: string): Promise<void> {
   }
 }
 
-export async function update(standard: Standard): Promise<boolean> {
+export async function update(standard: Standard, updateChecksum:boolean = false): Promise<boolean> {
   const checksum = await getChecksum(standard);
   const checksumFile = standard + '.md5';
   const exists = await fileExists(checksumFile);
@@ -48,6 +48,14 @@ export async function update(standard: Standard): Promise<boolean> {
   if (currentChecksum === checksum) {
     console.log(`Checksum for ${standard} is already up to date.`);
     return false;
+  }
+  if (updateChecksum){
+    try {
+      await writeToFile(checksumFile, checksum);
+      console.log(`Checksum for ${standard} updated successfully.`);
+    } catch (error) {
+      console.error(`Failed to update checksum for ${standard}:`, error);
+    }
   }
   return true;
 }


### PR DESCRIPTION
This pull request introduces changes to enhance functionality in the CLI for managing standards and updates, as well as updates to the workflow configuration. The most significant changes include adding a new CLI option to update checksum files, modifying the update logic to support this functionality, and renaming a GitHub Actions workflow for clarity.

### CLI Enhancements:
* [`cli.ts`](diffhunk://#diff-34610464905445a5c4c85ac0f5f0c6e5c1491d074f895606359e1c5b82390cc7L56-R68): Added a new `--write` (`-w`) option to the `update` command, allowing users to update the checksum file if it is outdated. This option defaults to `true`.
* [`cli.ts`](diffhunk://#diff-34610464905445a5c4c85ac0f5f0c6e5c1491d074f895606359e1c5b82390cc7L70-R80): Updated calls to `isUpdateAvailableForStandard` to pass the `--write` option as a parameter, enabling the new functionality.

### Update Logic:
* [`lib/update.ts`](diffhunk://#diff-e7e513f8960da36635d573e68ea8521d2256e76a7c871d0c06550f7e730c672eL33-R33): Modified the `update` function to accept an additional `updateChecksum` parameter (defaulting to `false`) and implemented logic to write the updated checksum to a file if this parameter is set to `true`. [[1]](diffhunk://#diff-e7e513f8960da36635d573e68ea8521d2256e76a7c871d0c06550f7e730c672eL33-R33) [[2]](diffhunk://#diff-e7e513f8960da36635d573e68ea8521d2256e76a7c871d0c06550f7e730c672eR52-R59)

### Workflow Configuration:
* [`.github/workflows/schedule.yml`](diffhunk://#diff-56c90529f7856eb163d7d81281b81d20c631080d3aa454d41103a06caa2bae04L1-R1): Renamed the workflow from "Build" to "Schedule" for better alignment with its purpose.